### PR TITLE
Avoid form submission without username validation

### DIFF
--- a/apps/authentication-portal/src/main/webapp/identifierauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/identifierauth.jsp
@@ -49,7 +49,7 @@
     }
 </script>
 
-<form class="ui large form" action="<%=loginFormActionURL%>" method="post" id="identifierForm">
+<form class="ui large form" action="<%=loginFormActionURL%>" method="post" id="identifierForm" onsubmit="event.preventDefault()">
     <%
         if (loginFormActionURL.equals(samlssoURL) || loginFormActionURL.equals(oauth2AuthorizeURL)) {
     %>


### PR DESCRIPTION
## Purpose
If we enable email username and try to use a non-email username, the form gets submitted despite the UI validation. This PR fixes that issue.